### PR TITLE
Change run.bat working directories

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,6 +1,6 @@
 set OSNAME=CustomOS
-set BUILDDIR=%0/../bin
-set OVMFDIR=%0/../../OVMFbin
+set BUILDDIR=%~dp0\bin
+set OVMFDIR=%~dp0\..\OVMFbin
 
-qemu-system-x86_64 -drive file=%BUILDDIR%/%OSNAME%.img -m 256M -cpu qemu64 -drive if=pflash,format=raw,unit=0,file="%OVMFDIR%/OVMF_CODE-pure-efi.fd",readonly=on -drive if=pflash,format=raw,unit=1,file="%OVMFDIR%/OVMF_VARS-pure-efi.fd" -net none
+qemu-system-x86_64 -drive file=%BUILDDIR%\%OSNAME%.img -m 256M -cpu qemu64 -drive if=pflash,format=raw,unit=0,file=%OVMFDIR%\OVMF_CODE-pure-efi.fd,readonly=on -drive if=pflash,format=raw,unit=1,file=%OVMFDIR%\OVMF_VARS-pure-efi.fd -net none
 pause


### PR DESCRIPTION
During my usage of `run.bat` I had problems with qemu not recognizing paths, however I have a fix.

One change is going from `%0` to `%~dp0`, which translates to "current directory without the file or filename" and the second one is removing the quotes in paths for `OVMFbin` stuff, also moving from `/` to `\` for windows directories